### PR TITLE
Fix login for smaller screens

### DIFF
--- a/scrape.py
+++ b/scrape.py
@@ -66,6 +66,7 @@ def main():
 def login(username, password, login_url, dashboard_url, posting_url, browser):
     # go to login page
     browser.get(login_url)
+    browser.execute_script("window.scrollTo(0, document.body.scrollHeight);")
     browser.find_element_by_class_name("btn--landing").click()
 
     # get username and password fields


### PR DESCRIPTION
For smaller screens, after running it you would get this error message

```
selenium.common.exceptions.ElementClickInterceptedException: Message: element click intercepted: Element <a class="btn--landing" href="https://waterlooworks.uwaterloo.ca/waterloo.htm?action=login">...</a> is not clickable at point 
(422, 653). Other element would receive the click: <div class="orbisFooter" style="position: fixed;">...</div>
```

By scrolling down, the login button will be in the viewport and not be blocked by the footer